### PR TITLE
Refine archive function

### DIFF
--- a/functions
+++ b/functions
@@ -767,7 +767,9 @@ ironjump_archive() {
     local folders=(
         "/root"
         "/home"
-        "/var/log"
+        "/opt/IronJump"
+        "/var/log/ironjump.log"
+        "/var/log/ironjump-autossh.log"
     )
 
     clear


### PR DESCRIPTION
Refined archive function to only take absolutely necessary logs and directories. Fixes #36.